### PR TITLE
changes to comments in inbox

### DIFF
--- a/CMPUT404Project/views.py
+++ b/CMPUT404Project/views.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from socialDist.models import Author, Post, Connection
 from socialDist.serializers import ConnectionSerializer, AuthorSerializer
+from socialDist.api_helper import is_follower
 import base64
 import json
 import marko
@@ -155,12 +156,18 @@ def create_post(request):
 
 @login_required
 def localComment(request, author_id, post_id):
-    author = Author.objects.get(user=request.user)
-    author_serial = AuthorSerializer(author)
+    current_author = Author.objects.get(user=request.user)
+    current_author_serial = AuthorSerializer(current_author)
     try:
-        post = Post.objects.filter(visibility="VISIBLE").get(id=HOST+"authors/"+author_id+"/posts/"+post_id)
+        author = Author.objects.get(id=HOST+"authors/"+author_id)
+    except Author.DoesNotExist:
+        return HttpResponse(status=404, content="Post does not exist")
+    try:
+        post = Post.objects.get(id=HOST+"authors/"+author_id+"/posts/"+post_id)
+        if post.visibility == "FRIENDS" and not is_follower(request.user, author):
+            return HttpResponse(status=404, content="Post does not exist")
         # author =  Author.objects.get(id=HOST+"authors/"+author_id)
-        context = {'post': post, 'author':json.dumps(author_serial.data)}
+        context = {'post': post, 'author':json.dumps(current_author_serial.data)}
         return render(request, 'post_comment.html', context)
     except Post.DoesNotExist:
         return HttpResponse(status=404, content="Post does not exist")

--- a/socialDist/templates/home.html
+++ b/socialDist/templates/home.html
@@ -72,7 +72,8 @@
             if (hostname == "https://social-distribution-w23-t17.herokuapp.com") {
                 url = `${hostname}/authors/${author_url}/posts/${parent_post_url}/comments/?page=1&size=1000`
             }
-            else if (hostname == "https://social-distribution-media.herokuapp.com") {
+            else if (hostname == "https://social-distribution-media.herokuapp.com" 
+            || hostname == "https:social-t30.herokuapp.com") {
                 url = `${hostname}/api/authors/${author_id}/posts/${post_id}/comments?page=1&size=1000`
             }
             const remoteConnection = listOfConnections.find(connection => connection.hostName === hostname);

--- a/socialDist/templates/profile.html
+++ b/socialDist/templates/profile.html
@@ -139,6 +139,7 @@
                     } else {
                         content = `<p class="card-text">${item.content}</p>`;
                     }
+                    // owner of a public post, can see comments and edit
                     if (item.author.id == current_author.id && item.visibility == "VISIBLE") {
                         editAndDeleteButtons = `<button type="button" id="edit-btn" class="btn btn-secondary btn-sm" onclick="editPost('${item.id}')">
                                         <i class="fa-solid fa-pen"></i>
@@ -151,14 +152,23 @@
                             <i class="fa-regular fa-comment"></i>
                         </button>`
                         getComment(item.author.id.split("/").pop(),item.id.split("/").pop(),'','internal')
-                    } else {
+                    // either owner of a private post OR not the owner of a public post, can see comments but can't edit
+                    } else if (item.visibility == "VISIBLE" || item.author.id == current_author.id) {
                         commentButton = 
                         `<button type="button" class="btn btn-secondary btn-sm" onclick="postComment('${item.id}','${item.author.id.split("/").pop()}','external')">
                             <i class="fa-regular fa-comment"></i>
                         </button>`
                         const post_url = new URL(item.id)
                         const host_name = post_url.hostname
-                        getComment(item.author.id.split("/").pop(),item.id.split("/").pop(),host_name,'external')
+                        let post_type = host_name === "socialdistcmput404.herokuapp.com" ? 'internal' : 'external';
+                        getComment(item.author.id.split("/").pop(),item.id.split("/").pop(),host_name, post_type)
+                    }
+                    // not the owner of a private post, can't see comments
+                    else {
+                        commentButton = 
+                        `<button type="button" class="btn btn-secondary btn-sm" onclick="postComment('${item.id}','${item.author.id.split("/").pop()}','external')">
+                            <i class="fa-regular fa-comment"></i>
+                        </button>`
                     }
                     var htmlElement = htmlToElement(`
                 <div class="card my-3">
@@ -525,7 +535,8 @@
             if (hostname == "https://social-distribution-w23-t17.herokuapp.com") {
                 url = `${hostname}/authors/${author_url}/posts/${parent_post_url}/comments/?page=1&size=1000`
             }
-            else if (hostname == "https://social-distribution-media.herokuapp.com") {
+            else if (hostname == "https://social-distribution-media.herokuapp.com" ||
+            hostname == "https:social-t30.herokuapp.com") {
                 url = `${hostname}/api/authors/${author_id}/posts/${post_id}/comments?page=1&size=1000`
             }
             const remoteConnection = listOfConnections.find(connection => connection.hostName === hostname);

--- a/socialDist/views.py
+++ b/socialDist/views.py
@@ -270,7 +270,7 @@ class APIPost(APIView):
             # Check if request is from an authorized source (only user and admin can call this!), 401 if not
             if not request.user.is_authenticated or (not request.user.is_staff and author_id != api_helper.extract_UUID(request.user.author.id )):
                 return Response(status=401)
-            if post.visibility == "PRIVATE":
+            if post.visibility == "FRIENDS":
                 return Response(status=404)
             postDict = dict(request.data)
             postDict["author"] = HOST+"authors/"+author_id
@@ -410,7 +410,7 @@ class APIImage(APIView):
         # Check if resource already exists, if it does, acts like a GET request
         try:
             post = Post.objects.get(pk=HOST+"authors/"+author_id+"/posts/"+post_id)
-            if post.visibility == "PRIVATE" and not api_helper.is_follower(request.user, author):
+            if post.visibility == "FRIENDS" and not api_helper.is_follower(request.user, author):
                 return Response(status=401)
             if post.contentType != "image/png;base64" and post.contentType != "image/jpeg;base64" and post.contentType != "image/jpg;base64":
                 return Response(status=404)
@@ -435,7 +435,7 @@ class APIComment(APIView):
         except Post.DoesNotExist:
             return Response(status=404)
         # for a private post, only the author can access the comments!
-        if post.visibility == "PRIVATE" and (not request.user.is_authenticated or request.user.author != author):
+        if post.visibility == "FRIENDS" and (not request.user.is_authenticated or request.user.author != author):
             return Response(status=401)
         try:
             comment = Comment.objects.filter(parentPost=HOST+
@@ -469,7 +469,7 @@ class APIListComments(APIView):
         except Post.DoesNotExist:
             return Response(status=404)
         # for a private post, only the author can access the comments!
-        if post.visibility == "PRIVATE" and (not request.user.is_authenticated or request.user.author != author):
+        if post.visibility == "FRIENDS" and (not request.user.is_authenticated or request.user.author != author):
             return Response(status=401)
         comments = Comment.objects.filter(parentPost=HOST+"authors/"+author_id+"/posts/"+post_id)
         serializer = CommentSerializer(comments, many=True)


### PR DESCRIPTION
This PR:
- Makes it so only the owner can see the comments on a private post in the inbox
- Adds checking when rendering comments to check if it's internal or external in the inbox
- Expanded URL of comment page to allow commenting on private internal posts, while adding protection to prevent user which aren't allowed to comment from accessing it